### PR TITLE
[kern] Fix compatiblity with newer Linux headers

### DIFF
--- a/kern/vmx.c
+++ b/kern/vmx.c
@@ -71,7 +71,9 @@ static unsigned long *msr_bitmap;
 
 #define NUM_SYSCALLS 312
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(3,11,0)
 typedef void (*sys_call_ptr_t)(void);
+#endif
 static sys_call_ptr_t dune_syscall_tbl[NUM_SYSCALLS] __cacheline_aligned;
 
 static DEFINE_PER_CPU(struct vmcs *, vmxarea);


### PR DESCRIPTION
Type 'sys_call_ptr_t' is already defined in Linux's public headers since
version 3.12. While an exact redefinition won't raise any compilation
errors, the signature was changed in Linux 4.4.
