### PR TITLE
[kern] Fix omission of the header for sys_call_ptr_t

### DIFF
--- a/kern/vmx.c
+++ b/kern/vmx.c
@@ -73,6 +73,8 @@ static unsigned long *msr_bitmap;
 
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(3,11,0)
 typedef void (*sys_call_ptr_t)(void);
+#else
+#include <asm/syscall.h>
 #endif
 static sys_call_ptr_t dune_syscall_tbl[NUM_SYSCALLS] __cacheline_aligned;
 


### PR DESCRIPTION
Compilation error "unknown type name ‘sys_call_ptr_t’" on kernel 4.4.0-57-generic. It can be solved by adding a proper header to kern/vmx.c.