### PR TITLE
TLB shootdown

### DIFF
--- a/kern/core.c
+++ b/kern/core.c
@@ -65,6 +65,11 @@ static int dune_enter(struct dune_config *conf, int64_t *ret)
 	return vmx_launch(conf, ret);
 }
 
+static void flush_guest_tlb(void *info)
+{
+	vpid_sync_vcpu_global();
+}
+
 static long dune_dev_ioctl(struct file *filp,
 			  unsigned int ioctl, unsigned long arg)
 {
@@ -116,6 +121,10 @@ static long dune_dev_ioctl(struct file *filp,
 
 	case DUNE_TRAP_DISABLE:
 		r = dune_trap_disable(arg);
+		break;
+
+	case DUNE_TLB_SHOOTDOWN:
+		r = on_each_cpu(flush_guest_tlb, NULL, 1);
 		break;
 
 	default:

--- a/kern/dune.h
+++ b/kern/dune.h
@@ -20,6 +20,7 @@
 #define DUNE_GET_LAYOUT	_IOW(DUNE_MINOR, 0x03, struct dune_layout)
 #define DUNE_TRAP_ENABLE _IOR(DUNE_MINOR, 0x04, struct dune_trap_config)
 #define DUNE_TRAP_DISABLE _IO(DUNE_MINOR, 0x05)
+#define DUNE_TLB_SHOOTDOWN _IO(DUNE_MINOR, 0x06)
 
 // XXX: Must match libdune/dune.h
 #define DUNE_SIGNAL_INTR_BASE 200

--- a/kern/vmx.c
+++ b/kern/vmx.c
@@ -222,7 +222,7 @@ static inline void vpid_sync_vcpu_single(u16 vpid)
 		__invvpid(VMX_VPID_EXTENT_SINGLE_CONTEXT, vpid, 0);
 }
 
-static inline void vpid_sync_vcpu_global(void)
+void vpid_sync_vcpu_global(void)
 {
 	if (cpu_has_vmx_invvpid_global())
 		__invvpid(VMX_VPID_EXTENT_ALL_CONTEXT, 0, 0);

--- a/kern/vmx.h
+++ b/kern/vmx.h
@@ -97,6 +97,8 @@ vmx_do_ept_fault(struct vmx_vcpu *vcpu, unsigned long gpa,
 extern void vmx_ept_sync_vcpu(struct vmx_vcpu *vcpu);
 extern void vmx_ept_sync_individual_addr(struct vmx_vcpu *vcpu, gpa_t gpa);
 
+extern void vpid_sync_vcpu_global(void);
+
 static __always_inline unsigned long vmcs_readl(unsigned long field)
 {
         unsigned long value;

--- a/libdune/dune.h
+++ b/libdune/dune.h
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 #include "mmu.h"
 #include "elf.h"
@@ -239,16 +240,19 @@ static inline int dune_tlb_shootdown(void)
 	long err = 0;
 
 	dune_fd = open("/dev/dune", O_RDWR);
-        if (dune_fd <= 0) {
-                dune_printf("dune: failed to open Dune device\n");
-                return -errno;
-        }
+	if (dune_fd <= 0) {
+		dune_printf("dune: failed to open Dune device\n");
+		return -errno;
+	}
 
 	err = ioctl(dune_fd, DUNE_TLB_SHOOTDOWN);
 	if (err) {
 		dune_printf("TLB shootdown failed: %ld\n", err);
+		close(dune_fd);
 		return -errno;
 	}
+
+	close(dune_fd);
 	return 0;
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,8 @@
 CC	= gcc
 CFLAGS	= -Wall -g -MD -O2 -I ../
+CXXFLAGS = -Wall -g -MD -O2 -std=c++11 -I ../
 
-all: hello test timetest test_sandbox hugepages hugepages_mod.ko
+all: hello test timetest test_sandbox tlb_shootdown hugepages hugepages_mod.ko
 
 hello: hello.o ../libdune/libdune.a
 	$(CC) $(CFLAGS) $(<) -o hello -L ../libdune -ldune -lpthread
@@ -11,6 +12,9 @@ timetest: timetest.o ../libdune/libdune.a
 
 test: test.o ../libdune/libdune.a
 	$(CC) $(CFLAGS) $(<) -o test -L ../libdune -ldune -lpthread
+
+tlb_shootdown: tlb_shootdown.o ../libdune/libdune.a
+	$(CXX) $(CXXFLAGS) $(<) -o tlb_shootdown -L ../libdune -ldune -lpthread
 
 test_sandbox: test_sandbox.o
 	$(CC) $(CFLAGS) -o $(@) $(<) -lpthread
@@ -22,7 +26,7 @@ hugepages_mod.ko: hugepages_mod.c
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) obj-m=hugepages_mod.o CFLAGS= modules
 
 clean:
-	rm -f *.o test *.d hello test test_sandbox hugepages
+	rm -f *.o test *.d hello test test_sandbox tlb_shootdown hugepages
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) obj-m=hugepages_mod.o clean
 
 -include *.d

--- a/test/tlb_shootdown.cpp
+++ b/test/tlb_shootdown.cpp
@@ -1,0 +1,118 @@
+#include <cstdio>
+#include <iostream>
+#include <thread>
+
+#include <sys/mman.h>
+
+extern "C" {
+#include "libdune/dune.h"
+}
+
+using namespace std;
+
+volatile bool swap_mappings = false;
+bool tlb_shootdown = false;
+
+static void pgflt_handler(uintptr_t addr, uint64_t fec, struct dune_tf *tf)
+{
+	ptent_t *pte;
+	dune_vm_lookup(pgroot, (void *) addr, CREATE_NORMAL, &pte);
+	if (addr >= mmap_base && addr < (mmap_base + 2 * PGSIZE)) {
+		if (!swap_mappings) {
+			*pte = PTE_P | PTE_W | PTE_ADDR(dune_va_to_pa((void *)addr));
+		} else {
+			uintptr_t va = (addr - mmap_base) < PGSIZE ?
+				addr + PGSIZE : addr - PGSIZE;
+			*pte = PTE_P | PTE_W | PTE_ADDR(dune_va_to_pa((void *)va));
+			if (tlb_shootdown) {
+				dune_tlb_shootdown();
+			}
+		}
+	} else {
+		*pte = PTE_P | PTE_W | PTE_ADDR(dune_va_to_pa((void *)addr));
+	}
+}
+
+static void init_dune()
+{
+	int err = dune_init(0);
+	if (err) {
+		cerr << "Dune init error!" << endl;
+		exit(err);
+	}
+	dune_register_pgflt_handler(pgflt_handler);
+}
+
+void print_thread_view(const char *thread)
+{
+    cout << thread << " thread view:" << endl;
+	uintptr_t p = mmap_base;
+	cout << "\t" << (void *)p << " ==> " << (char *)p << endl;
+	p += PGSIZE;
+	cout << "\t" << (void *)p << " ==> " << (char *)p << endl;
+}
+
+void thread_work()
+{
+	dune_enter();
+
+	assert(!swap_mappings);
+	print_thread_view("another");
+
+	swap_mappings = true;
+	while (swap_mappings) { }
+
+	print_thread_view("another");
+}
+
+void main_work() {
+	assert(!swap_mappings);
+	print_thread_view("main");
+
+	while (!swap_mappings) { }
+
+	dune_vm_unmap(pgroot, (void *)mmap_base, 2 * PGSIZE);
+	cout << "(the main thread swaps the mappings...)" << endl;
+	print_thread_view("main");
+
+	swap_mappings = false;
+}
+
+int main(int argc, char *argv[])
+{
+	init_dune();
+
+	if (mmap((void *)PGADDR(mmap_base), 2 * PGSIZE,
+		PROT_READ|PROT_WRITE, MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
+		-1, 0) != (void *)mmap_base) {
+		cerr << "mmap failed for " << (void *)mmap_base << endl;
+		return errno;
+	}
+
+	uintptr_t p = mmap_base;
+	sprintf((char *)p, "guest physical page %d", 0);
+	p += PGSIZE;
+	sprintf((char *)p, "guest physical page %d", 1);
+
+	int err = dune_enter();
+	if (err){
+		cerr << "Dune enter error!" << endl;
+		return err;
+	}
+
+	cout << "Without TLB shootdown:" << endl;
+	thread tx = thread(thread_work);
+	main_work();
+	tx.join();
+
+	dune_vm_unmap(pgroot, (void *)mmap_base, 2 * PGSIZE);
+
+	cout << endl << "With TLB shootdown:" << endl;
+	tlb_shootdown = true;
+	tx = thread(thread_work);
+	main_work();
+	tx.join();
+
+	return 0;
+}
+


### PR DESCRIPTION
I think TLB shootdown is a very necessary function for Dune, because any thread that changes page mappings need this to let other threads know. Implementation details are mentioned in the commit messages. The idea is to reuse the existing inter-processor interrupt mechanism in the Linux kernel, instead of remaking one in libdune, for both simplicity and reliability.

A test is included. BTW, that program is in C++, so it can be a reference for users who want to use Dune with C++.